### PR TITLE
Add arosics to osx-arm64 migration.

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -1065,3 +1065,4 @@ scikit-sparse
 scikit-network
 pybamm
 nifty
+arosics


### PR DESCRIPTION
This add arosics to the OSX ARM64 migration.